### PR TITLE
fixed require autoload path in test bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,4 +8,4 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__.'/../../../../vendor/autoload.php';
+require_once __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
Changed require for autoload in test bootstrap  for fix this error

```
PHP Warning:  require_once(../AeroGear-Push/tests/../../../../vendor/autoload.php): failed to open stream: No such file or directory in ../AeroGear-Push/tests/bootstrap.php on line 11
```